### PR TITLE
Update nvt-plugins-sync-hook.yaml

### DIFF
--- a/chart/gvm/templates/nvt-plugins-sync-hook.yaml
+++ b/chart/gvm/templates/nvt-plugins-sync-hook.yaml
@@ -20,7 +20,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ tpl .Values.image.openvas.registry . }}/{{ tpl .Values.image.openvas.repository . }}:{{ tpl .Values.image.openvas.tag . }}"
           imagePullPolicy: {{ .Values.image.openvas.pullPolicy }}
-          command: ["greenbone-nvt-sync"]
+          command: ["greenbone-nvt-sync --rsync"]
           volumeMounts:
             - name: data-volume
               subPath: {{ include "gvm.dataSubPathPrefix" . }}plugins


### PR DESCRIPTION
Hii

You should receive 4 Pr's from me (since I was lazy I did this through the UI, plus I'm not sure whether they need changing in all areas)

https://github.com/greenbone/openvas/issues/476 

shows that greenbone-nvt-sync --rsync is the way to go now, and I am getting errors currently when using the docker compose command with the nvt sync command