### PR TITLE
Use post-installation helm chart hook for feeds sync

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,9 +54,21 @@ namespace and then install the helm chart:
 kubectl create namespace gvm
 
 helm install gvm \
-    https://github.com/admirito/gvm-containers/releases/download/chart-1.0.0/gvm-1.0.0.tgz \
-    --namespace gvm --timeout 15m \
+    https://github.com/admirito/gvm-containers/releases/download/chart-1.0.1/gvm-1.0.1.tgz \
+    --namespace gvm --timeout 20m \
     --set gvmd-db.postgresqlPassword="mypassword"
+#+END_SRC
+
+By default the =syncFeedsAfterInstall= option is enabled, so a
+post-installation hook tries to update all the GVM feeds and it may
+slow down the installation process considerably. You can view the
+feeds sync post installation progress by =kubectl logs= command:
+
+#+NAME: install on the kubernetes cluster
+#+BEGIN_SRC shell
+NS=gvm
+
+kubectl logs -n $NS -f $(kubectl get pod -n $NS -l job-name=gvm-feeds-sync -o custom-columns=:metadata.name --no-headers)
 #+END_SRC
 
 For more information and see other options please read the

--- a/chart/README.org
+++ b/chart/README.org
@@ -38,7 +38,7 @@ Then you can install the chart with helm:
 
 #+NAME: install GVM helm chart
 #+BEGIN_SRC shell
-helm install gvm ./gvm-*.tgz --namespace gvm --timeout 15m --set gvmd-db.postgresqlPassword="mypassword"
+helm install gvm ./gvm-*.tgz --namespace gvm --timeout 20m --set gvmd-db.postgresqlPassword="mypassword"
 #+END_SRC
 
 You have to also provide =persistence= configuration, to make sure your
@@ -55,7 +55,7 @@ of the GVM chart and their default values. For a complete list see
 | image.gsad.tag                                 | the docker tag for gsad image                                | 20      |
 | image.openvas.tag                              | the docker tag for openvas image                             | 20      |
 | gvmd-db.image.tag                              | the docker tag for gvm-postgres image                        | 20      |
-| syncFeedsBeforeInstall                         | sync all the GVM feeds with pre-install hooks                | true    |
+| syncFeedsAfterInstall                          | sync all the GVM feeds with post-install hooks               | true    |
 | persistence.existingClaim                      | name of an existing pvc for data (nvt/scap/cert) persistence | ""      |
 | gvmd-db.postgresqlPassword                     | the password for "gvmduser" in "gvmd" postgresql database    | ""      |
 | gvmd-db.persistence.existingClaim              | name of an existing pvc for postgresql data persistence      | ""      |

--- a/chart/gvm/Chart.yaml
+++ b/chart/gvm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gvm
-version: 1.0.0
+version: 1.0.1
 appVersion: "20.08"
 description: The Greenbone Vulnerability Management Solution (previously known as Open Vulnerability Assessment System) i.e. a remote network security auditing tool
 keywords:

--- a/chart/gvm/templates/feeds-sync-hook.yaml
+++ b/chart/gvm/templates/feeds-sync-hook.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.syncFeedsBeforeInstall (and .Values.customFeedsServer.enabled .Values.customFeedsServer.syncFeedsAfterInstall)) }}
+{{- if (or .Values.syncFeedsAfterInstall .Values.customFeedsServer.enabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -6,11 +6,7 @@ metadata:
   labels:
   {{- include "gvm.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.customFeedsServer.enabled }}
     helm.sh/hook: post-install,post-upgrade
-    {{- else }}
-    helm.sh/hook: pre-install,pre-upgrade
-    {{- end }}
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:

--- a/chart/gvm/values.yaml
+++ b/chart/gvm/values.yaml
@@ -100,9 +100,9 @@ extraEnv:
   gsad: []
   openvas: []
 
-# update all the nvt, scap, cert and gvmd data feeds in a pre
+# update all the nvt, scap, cert and gvmd data feeds in a post
 # installation hook
-syncFeedsBeforeInstall: true
+syncFeedsAfterInstall: true
 
 customFeedsServer:
   # Enable a deployment with a custom image that could be used as a
@@ -118,9 +118,6 @@ customFeedsServer:
     port: 873
     containerPort: 873
   resources: {}
-  # Disable `syncFeedsBeforeInstall`; use the custom feed server after
-  # install instead
-  syncFeedsAfterInstall: true
   # Configure gvmd and openvas deployments to use the custom feed
   # server service
   setDefaultFeedServerForGVM: true


### PR DESCRIPTION
The hook requires PVCs that installation process creates and it cannot
be done in a pre-installation hook.

Closes #27