### PR TITLE
Wrong image name in nvt-sync.yml

### DIFF
--- a/nvt-sync.yml
+++ b/nvt-sync.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   nvt-sync:
-    image: admirito/openvas:21
+    image: admirito/openvas-scanner:21
     volumes:
       - openvas-var-lib:/var/lib/openvas
       - run-gvm:/run/gvm


### PR DESCRIPTION
Wrong image in nvt-sync.yml file. This will fix:

> ERROR: manifest for admirito/openvas:21 not found: manifest unknown: manifest unknown